### PR TITLE
Update README.md with Geoconnex scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ A collection of all things awesome related to the [Dagster](https://dagster.io) 
 - [NBA Player Stats Dagster Project with Dagster-DBT Integration](https://github.com/gbemike/nba_pipeline)
 - [Slack Data backup using Dagster, dlthub, and Iceberg](https://github.com/Kayrnt/dlt-iceberg-slack-backup/tree/main)
 - [Urban growth hotspots across Australia for $15](https://github.com/kubox-ai/urban-extent)
+- [Geoconnex.us Scheduler](https://github.com/internetofwater/scheduler) - Production web crawler using Dagster with CI/CD and Docker; Harvests US water data into a knowledge graph
 
 ## Discussion
 


### PR DESCRIPTION
I was hoping to add a reference to my organization's project, the [Geoconnex Scheduler](https://github.com/internetofwater/scheduler). The Geoconnex project is a federally funded project aiming to create a knowledge graph linking hydrologic features in the United States. More info can be found [on the docs](https://docs.geoconnex.us/)

The core of the repo is all dagster and there are a lot of examples that others could hopefully benefit from. We have uv, pytest, github actions, infrastructure as code, Docker deployment, debugging with vscode, and a lot of other features.

All our code is licensed Apache 2.0 so we will like for others to be able to benefit from it as well. 